### PR TITLE
Add redirection if there is no locale in URL

### DIFF
--- a/app/api/rest-client/route.ts
+++ b/app/api/rest-client/route.ts
@@ -51,7 +51,6 @@ const handleRequest = async (
         { status: axiosError.response?.status || 500 },
       );
     } else if (error instanceof Error) {
-
       return NextResponse.json(
         { error: error.message, status: 500 },
         { status: 500 },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+import { i18n } from './i18n-config';
+import { LanguageType } from './src/components/LanguageToggle/LanguageToggle';
+
+export function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // Check if there is any supported locale in the pathname
+  const pathnameIsMissingLocale = i18n.locales.every(
+    (locale) =>
+      !pathname.startsWith(`/${locale}/`) && pathname !== `/${locale}`,
+  );
+
+  // Redirect if there is no locale
+  if (pathnameIsMissingLocale) {
+    const locale: LanguageType = i18n.defaultLocale;
+
+    return NextResponse.redirect(
+      new URL(
+        `/${locale}${pathname.startsWith('/') ? '' : '/'}${pathname}`,
+        request.url,
+      ),
+    );
+  }
+}
+
+export const config = {
+  // Matcher ignoring `/_next/` and `/api/`
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
Now you'll be automatically redirected to the default locale route, which is '/en' if you haven't specified it in URL.